### PR TITLE
Use contentType assertion instead of checking header to ensure compatibility with Quarkus 2.9.1+

### DIFF
--- a/quarkus-todo-reactive/src/test/java/io/quarkus/sample/TodoResourceIT.java
+++ b/quarkus-todo-reactive/src/test/java/io/quarkus/sample/TodoResourceIT.java
@@ -26,7 +26,7 @@ public class TodoResourceIT {
         // No data inserted.
         List<Todo> todos = get("/api").then()
                 .statusCode(HttpStatus.SC_OK)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .extract().body().as(getTodoTypeRef());
         assertEquals(0, todos.size());
     }
@@ -38,20 +38,20 @@ public class TodoResourceIT {
         todo.title = "testing the application";
         given()
                 .body(todo)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
                 .when()
                 .post("/api")
                 .then()
                 .statusCode(HttpStatus.SC_CREATED)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .body("title", is(todo.title))
                 .body("completed", is(false))
                 .body("id", is(1));
 
         List<Todo> todos = get("/api").then()
                 .statusCode(HttpStatus.SC_OK)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .extract().body().as(getTodoTypeRef());
         assertEquals(1, todos.size());
     }
@@ -64,14 +64,14 @@ public class TodoResourceIT {
         todo.completed = true;
         given()
                 .body(todo)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
                 .pathParam("id", 1)
                 .when()
                 .patch("/api/{id}")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .body("title", is(todo.title))
                 .body("completed", is(true))
                 .body("id", is(1));
@@ -81,7 +81,7 @@ public class TodoResourceIT {
     @Order(4)
     void testDeletingAnItem() {
         given()
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
                 .pathParam("id", 1)
                 .when()
@@ -91,7 +91,7 @@ public class TodoResourceIT {
 
         List<Todo> todos = get("/api").then()
                 .statusCode(HttpStatus.SC_OK)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .extract().body().as(getTodoTypeRef());
         assertEquals(0, todos.size());
     }

--- a/quarkus-todo-reactive/src/test/java/io/quarkus/sample/TodoResourceTest.java
+++ b/quarkus-todo-reactive/src/test/java/io/quarkus/sample/TodoResourceTest.java
@@ -32,7 +32,7 @@ class TodoResourceTest {
 
         get("/api/1").then()
                 .statusCode(HttpStatus.SC_OK)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .body("title", is("Introduction to Quarkus"))
                 .body("completed", is(true));
     }
@@ -44,13 +44,13 @@ class TodoResourceTest {
         todo.title = "testing the application";
         given()
                 .body(todo)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
                 .when()
                 .post("/api")
                 .then()
                 .statusCode(HttpStatus.SC_CREATED)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .body("title", is(todo.title))
                 .body("completed", is(false))
                 .body("id", is(5));
@@ -69,14 +69,14 @@ class TodoResourceTest {
         todo.completed = true;
         given()
                 .body(todo)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
                 .pathParam("id", 5)
                 .when()
                 .patch("/api/{id}")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .body("title", is(todo.title))
                 .body("completed", is(true))
                 .body("id", is(5));
@@ -86,7 +86,7 @@ class TodoResourceTest {
     @Order(4)
     void testDeletingAnItem() {
         given()
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
                 .pathParam("id", 5)
                 .when()

--- a/quarkus-todo/src/test/java/io/quarkus/sample/TodoResourceIT.java
+++ b/quarkus-todo/src/test/java/io/quarkus/sample/TodoResourceIT.java
@@ -29,7 +29,7 @@ public class TodoResourceIT {
         // No data inserted.
         List<Todo> todos = get("/api").then()
                 .statusCode(HttpStatus.SC_OK)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .extract().body().as(getTodoTypeRef());
         assertEquals(0, todos.size());
     }
@@ -41,20 +41,20 @@ public class TodoResourceIT {
         todo.title = "testing the application";
         given()
                 .body(todo)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
                 .when()
                 .post("/api")
                 .then()
                 .statusCode(HttpStatus.SC_CREATED)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .body("title", is(todo.title))
                 .body("completed", is(false))
                 .body("id", is(1));
 
         List<Todo> todos = get("/api").then()
                 .statusCode(HttpStatus.SC_OK)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .extract().body().as(getTodoTypeRef());
         assertEquals(1, todos.size());
     }
@@ -67,14 +67,14 @@ public class TodoResourceIT {
         todo.completed = true;
         given()
                 .body(todo)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
                 .pathParam("id", 1)
                 .when()
                 .patch("/api/{id}")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .body("title", is(todo.title))
                 .body("completed", is(true))
                 .body("id", is(1));
@@ -84,7 +84,7 @@ public class TodoResourceIT {
     @Order(4)
     void testDeletingAnItem() {
         given()
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
                 .pathParam("id", 1)
                 .when()
@@ -94,7 +94,7 @@ public class TodoResourceIT {
 
         List<Todo> todos = get("/api").then()
                 .statusCode(HttpStatus.SC_OK)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .extract().body().as(getTodoTypeRef());
         assertEquals(0, todos.size());
     }

--- a/quarkus-todo/src/test/java/io/quarkus/sample/TodoResourceTest.java
+++ b/quarkus-todo/src/test/java/io/quarkus/sample/TodoResourceTest.java
@@ -27,13 +27,13 @@ class TodoResourceTest {
     void testInitialItems() {
         List<Todo> todos = get("/api").then()
                 .statusCode(HttpStatus.SC_OK)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .extract().body().as(getTodoTypeRef());
         assertEquals(4, todos.size());
 
         get("/api/1").then()
                 .statusCode(HttpStatus.SC_OK)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .body("title", is("Introduction to Quarkus"))
                 .body("completed", is(true));
     }
@@ -45,20 +45,20 @@ class TodoResourceTest {
         todo.title = "testing the application";
         given()
                 .body(todo)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
                 .when()
                 .post("/api")
                 .then()
                 .statusCode(HttpStatus.SC_CREATED)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .body("title", is(todo.title))
                 .body("completed", is(false))
                 .body("id", is(5));
 
         List<Todo> todos = get("/api").then()
                 .statusCode(HttpStatus.SC_OK)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .extract().body().as(getTodoTypeRef());
         assertEquals(5, todos.size());
     }
@@ -71,14 +71,14 @@ class TodoResourceTest {
         todo.completed = true;
         given()
                 .body(todo)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
                 .pathParam("id", 5)
                 .when()
                 .patch("/api/{id}")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .body("title", is(todo.title))
                 .body("completed", is(true))
                 .body("id", is(5));
@@ -88,7 +88,7 @@ class TodoResourceTest {
     @Order(4)
     void testDeletingAnItem() {
         given()
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
                 .pathParam("id", 5)
                 .when()
@@ -98,7 +98,7 @@ class TodoResourceTest {
 
         List<Todo> todos = get("/api").then()
                 .statusCode(HttpStatus.SC_OK)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .extract().body().as(getTodoTypeRef());
         assertEquals(4, todos.size());
     }
@@ -112,7 +112,7 @@ class TodoResourceTest {
 
         List<Todo> todos = get("/api").then()
                 .statusCode(HttpStatus.SC_OK)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
                 .extract().body().as(getTodoTypeRef());
         assertEquals(3, todos.size());
     }


### PR DESCRIPTION
See discussion in https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/.E2.9C.94.20resteasy-reactive-jackson.20Content-Type.20changed.20in.202.2E9.2E1.3F/near/284845778. This repo doesn't have a problem *yet*, but if it upgrades Quarkus it will.

In Quarkus 2.9.1 and higher, the content type is `application/json;charset=UTF-8` rather than `application/json`, which is what the tests expect. Instead of getting the header, we can use the RestAssured .contentType method, which cleanly handles stripping out the charset from the header. It's also shorter, as a bonus. 

I've tested with `TESTCONTAINERS_RYUK_DISABLED="true" mvn install` and all is well. 